### PR TITLE
Ensure chaddr is packed to the correct size

### DIFF
--- a/lib/net/dhcp/core.rb
+++ b/lib/net/dhcp/core.rb
@@ -160,7 +160,7 @@ module DHCP
       if self.chaddr.size >= 16
         out << self.chaddr.pack('C16')
       else
-        out << (self.chaddr + [0x00]*(19-self.chaddr.size)).pack('C16')
+        out << (self.chaddr + [0x00]*(16-self.chaddr.size)).pack('C16')
       end
       
       # sname and file


### PR DESCRIPTION
If chaddr has fewer than, or more than 16 bytes an invalid packet will be created. This change will pad the chaddr field if less than 16 bytes, and truncate it if larger.

Let me know if this is the right place to push this change, as I noticed you maintain the rubygems package.
