### PR TITLE
fix raise calling

### DIFF
--- a/lib/net/dhcp/core.rb
+++ b/lib/net/dhcp/core.rb
@@ -108,7 +108,7 @@ module DHCP
       # message operation and options. We need at least an operation and a 
       # MessageTypeOption to create a DHCP message!!
       if (([:op, :options]  & params.keys).size != 2)
-        raise ArgumentError('you need to specify at least values for :op and :options') 
+        raise ArgumentError, 'you need to specify at least values for :op and :options'
       end
       
       self.op = params[:op]
@@ -119,7 +119,7 @@ module DHCP
         next unless opt.class == MessageTypeOption
         found = true
       end
-      raise ArgumentError(':options must include a MessageTypeOption') unless found
+      raise ArgumentError, ':options must include a MessageTypeOption' unless found
     
       #hardware type and length of the hardware address
       self.htype = params.fetch(:htype, $DHCP_HTYPE_ETHERNET)

--- a/lib/net/dhcp/options.rb
+++ b/lib/net/dhcp/options.rb
@@ -33,7 +33,7 @@ module DHCP
     def initialize(params = {})
       # We need a type, and a payload
       if (([:type, :payload] & params.keys).size != 2)
-        raise ArgumentError('you need to specify values for :type and :payload')
+        raise ArgumentError, 'you need to specify values for :type and :payload'
       end
 
       self.type = params[:type]


### PR DESCRIPTION
raise accept class and message as 2 arguments
    $ ruby -e "raise ArgumentError('you need to specify at least values for :op and :options')"
    -e:1:in `<main>': undefined method`ArgumentError' for main:Object (NoMethodError)
