### PR TITLE
fix payload for Discover

### DIFF
--- a/lib/net/dhcp/core.rb
+++ b/lib/net/dhcp/core.rb
@@ -293,7 +293,7 @@ module DHCP
   class Request < Message
     def initialize(params={})
       params[:op] = $DHCP_OP_REQUEST
-      params[:options] = params.fetch(:options, [MessageTypeOption.new({:payload=>$DHCP_MSG_REQUEST}), ParameterRequestListOption.new])
+      params[:options] = params.fetch(:options, [MessageTypeOption.new({:payload=>[$DHCP_MSG_REQUEST]}), ParameterRequestListOption.new])
       super(params)
     end
   end
@@ -311,7 +311,7 @@ module DHCP
     def initialize(params={})
       params[:op] = $DHCP_OP_REPLY
       params[:options] = params.fetch(:options, [
-      MessageTypeOption.new({:payload=>$DHCP_MSG_ACK}), 
+      MessageTypeOption.new({:payload=>[$DHCP_MSG_ACK]}), 
       ServerIdentifierOption.new,
       DomainNameOption.new
       ])
@@ -331,7 +331,7 @@ module DHCP
     def initialize(params={})
       params[:op] = $DHCP_OP_REQUEST
       params[:options] = params.fetch(:options, [
-      MessageTypeOption.new({:payload=>$DHCP_MSG_RELEASE}), 
+      MessageTypeOption.new({:payload=>[$DHCP_MSG_RELEASE]}), 
       ServerIdentifierOption.new
       ])
       super(params)
@@ -343,7 +343,7 @@ module DHCP
   class Inform < Message
     def initialize(params={})
       params[:op] = $DHCP_OP_REQUEST
-      params[:options] = params.fetch(:options, [MessageTypeOption.new({:payload=>$DHCP_MSG_INFORM}), ParameterRequestListOption.new])
+      params[:options] = params.fetch(:options, [MessageTypeOption.new({:payload=>[$DHCP_MSG_INFORM]}), ParameterRequestListOption.new])
       super(params)
     end
   end

--- a/lib/net/dhcp/options.rb
+++ b/lib/net/dhcp/options.rb
@@ -44,7 +44,7 @@ module DHCP
     # Return the option packed as an array of bytes. The first two elements
     # are the type and length of this option. The payload follows afterwards.
     def to_a
-      return [self.type, self.len] + [self.payload]
+      return [self.type, self.len] + self.payload
     end
 
     # Return the option packed as a binary string.
@@ -255,7 +255,7 @@ module DHCP
     #DEBUG
     def initialize(params={})
       params[:type] = $DHCP_MESSAGETYPE
-      params[:payload] = params.fetch(:payload, $DHCP_MSG_DISCOVER)
+      params[:payload] = params.fetch(:payload, [$DHCP_MSG_DISCOVER])
       super(params)
     end
 


### PR DESCRIPTION
```
$ ruby -e 'require "net-dhcp"; DHCP::Offer.new.options[0].to_a'
```

cause no implicit conversion of Fixnum into Array (TypeError), so this patch should fix it
