### PR TITLE
Fix gemfile

### DIFF
--- a/bin/net-dhcp
+++ b/bin/net-dhcp
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 # main.rb
 # 4 de octubre de 2007
 #


### PR DESCRIPTION
Hi,

I made a few changes to bin/net-dhcp so that you don't get socket errors if the socket is already in use by another dhcp server.

I also added dependencies to the gemset that were required by bin/net-dhcp. The 'ipaddress' gem is still required but the mistake is in the 'dhcp' gem, not yours.

Thanks,
Michael
