### PR TITLE
Add Windows support to DHCP requests

### DIFF
--- a/lib/net/dhcp/core.rb
+++ b/lib/net/dhcp/core.rb
@@ -22,6 +22,8 @@
 **
 =end
 
+require 'rubygems'
+
 module DHCP
   # -------------------------------------------------------------- dhcp messages
   class Message
@@ -145,7 +147,14 @@ module DHCP
         self.chaddr = params[:chaddr]
         raise 'chaddr field should be of 16 bytes' unless self.chaddr.size == 16
       else
-        mac = `/sbin/ifconfig | grep HWaddr | cut -c39- | head -1`.chomp.strip.gsub(/:/,'')
+        if Gem.respond_to?(:win_platform?) && Gem.win_platform?
+          mac_line = `getmac /fo list`.split("\n").grep(/Physical Address/).first
+          if mac_line
+            mac = mac_line.strip.split(":")[1].gsub("-","").strip
+          end
+        else
+          mac = `/sbin/ifconfig | grep HWaddr | cut -c39- | head -1`.chomp.strip.gsub(/:/,'')
+        end
         mac = '000000000000' if mac.empty?
         self.chaddr = [mac].pack('H*').unpack('CCCCCC')
         self.chaddr += [0x00]*(16-self.chaddr.size)


### PR DESCRIPTION
Hello,

Self explanatory I hope. So this came about trying to get the IP of the metadata service on Azure cloud, which is embedded in the DHCP response.  Have tested this out on Windows server 2008/2012/Windows 8. Would really appreciate a merge and a rev. bump, let me know if I need to change anything.
